### PR TITLE
[🌎 Feature] User Entity와 Plan 구현 

### DIFF
--- a/entity/common-fields.go
+++ b/entity/common-fields.go
@@ -1,0 +1,3 @@
+package entity
+
+type Id uint

--- a/entity/user/plan.go
+++ b/entity/user/plan.go
@@ -1,0 +1,38 @@
+package entities
+
+type plan struct {
+	level int8
+	name  string
+}
+
+const (
+	FREE  = "FREE"
+	JJANG = "JJANG"
+)
+
+var plans map[string]plan
+
+func initPlans() {
+	plans = map[string]plan{
+		FREE:  {name: FREE, level: 1},
+		JJANG: {name: JJANG, level: 2},
+	}
+}
+
+func Free() plan {
+	if plans == nil {
+		initPlans()
+	}
+	return plans[FREE]
+}
+
+func Jjang() plan {
+	if plans == nil {
+		initPlans()
+	}
+	return plans[JJANG]
+}
+
+func (plan plan) IsBetter(another plan) bool {
+	return plan.level > another.level
+}

--- a/entity/user/plan.go
+++ b/entity/user/plan.go
@@ -13,6 +13,10 @@ const (
 var plans map[string]plan
 
 func initPlans() {
+	if plans != nil {
+		return
+	}
+
 	plans = map[string]plan{
 		FREE:  {name: FREE, level: 1},
 		JJANG: {name: JJANG, level: 2},
@@ -20,19 +24,15 @@ func initPlans() {
 }
 
 func Free() plan {
-	if plans == nil {
-		initPlans()
-	}
+	initPlans()
 	return plans[FREE]
 }
 
 func Jjang() plan {
-	if plans == nil {
-		initPlans()
-	}
+	initPlans()
 	return plans[JJANG]
 }
 
-func (plan plan) IsBetter(another plan) bool {
+func (plan *plan) IsBetter(another *plan) bool {
 	return plan.level > another.level
 }

--- a/entity/user/plan.go
+++ b/entity/user/plan.go
@@ -1,4 +1,4 @@
-package entities
+package entity
 
 type plan struct {
 	level int8

--- a/entity/user/user.go
+++ b/entity/user/user.go
@@ -1,4 +1,4 @@
-package entities
+package entity
 
 import "guestbook/entity"
 

--- a/entity/user/user.go
+++ b/entity/user/user.go
@@ -1,0 +1,11 @@
+package entities
+
+import "guestbook/entity"
+
+type User struct {
+	id entity.Id
+}
+
+func (user *User) Id() entity.Id {
+	return user.id
+}

--- a/entity/user/user.go
+++ b/entity/user/user.go
@@ -3,9 +3,14 @@ package entities
 import "guestbook/entity"
 
 type User struct {
-	id entity.Id
+	id   entity.Id
+	plan plan
 }
 
 func (user *User) Id() entity.Id {
 	return user.id
+}
+
+func (user *User) Plan() plan {
+	return user.plan
 }

--- a/register/map.go
+++ b/register/map.go
@@ -1,7 +1,9 @@
 package register
 
+import "guestbook/entity"
+
 type RGBMap struct {
-	id   string
+	id   entity.Id
 	data map[string]LWWRegister
 }
 

--- a/register/register.go
+++ b/register/register.go
@@ -12,7 +12,8 @@ func (register *LWWRegister) Merge(remoteState State) {
 	if localState.timestamp > remoteState.timestamp {
 		return
 	}
-	if localState.timestamp == remoteState.timestamp && localState.peer > remoteState.peer {
+	if localState.timestamp == remoteState.timestamp &&
+		localState.user.Id() > remoteState.user.Id() {
 		return
 	}
 

--- a/register/register.go
+++ b/register/register.go
@@ -13,7 +13,7 @@ func (register *LWWRegister) Merge(remoteState State) {
 		return
 	}
 	if localState.timestamp == remoteState.timestamp &&
-		localState.user.Id() > remoteState.user.Id() {
+		localState.user.Id() < remoteState.user.Id() {
 		return
 	}
 

--- a/register/state.go
+++ b/register/state.go
@@ -1,9 +1,12 @@
 package register
 
-import "guestbook/rgb"
+import (
+	entities "guestbook/entity/user"
+	"guestbook/rgb"
+)
 
 type State struct {
-	peer      string
+	user      entities.User
 	timestamp uint
 	value     rgb.RGB
 }

--- a/register/state.go
+++ b/register/state.go
@@ -1,12 +1,12 @@
 package register
 
 import (
-	entities "guestbook/entity/user"
+	entity "guestbook/entity/user"
 	"guestbook/rgb"
 )
 
 type State struct {
-	user      entities.User
+	user      entity.User
 	timestamp uint
 	value     rgb.RGB
 }


### PR DESCRIPTION
## 📒 Issue
#5

## 🎯 어떤 작업을 했는지
유저 엔티티와 Plan 구현


## 📜 자세한 설명
유저 엔티티는 peer 값을 대체하기 위한 id와 plan만 추가한다.
plan은 보통 프로젝트의 role과 비슷한 개념으로 id 외의 우선순위 비교와 관리를 위해 구현. 최대한 Java Enum과 비슷하게 짜려 했는데, 맘에 안 든다. 그냥 다른 사람들이 많이 다루는 방식처럼 iota를 활용해 아예 숫자로만 나타내게 하는 방법도 괜찮을 것 같다. 

여기서 발생할 수 있는 문제는 클라이언트가 권한을 확인하기 어렵다는 것이다. 달랑 숫자로만 넘겨주면 파악하기 힘들 것 같다. (어차피 String이어도 변화에 취약한건 똑같지만.. 조금 더 고민해보자)

Plan은 일단 기본 플랜인 Free와 상위 plan인 JJANG을 구현해봤다.

id는 여러 엔티티들에서 활용할 수도 있을 것 같아 따로 type으로 만들었다