### PR TITLE
[🛠️ Refactor] 그림 및 레지스터 관련 type 래핑과 #10, #19 수행 (변경 용이, 가독성, 실수 방지)

### DIFF
--- a/common/coord/coord.go
+++ b/common/coord/coord.go
@@ -1,0 +1,4 @@
+package coord
+
+type X uint16
+type Y uint16

--- a/entity/user/plan.go
+++ b/entity/user/plan.go
@@ -1,4 +1,4 @@
-package entity
+package user
 
 type plan struct {
 	level int8

--- a/entity/user/user.go
+++ b/entity/user/user.go
@@ -1,4 +1,4 @@
-package entity
+package user
 
 import "guestbook/entity"
 

--- a/register/canvas.go
+++ b/register/canvas.go
@@ -1,27 +1,22 @@
 package register
 
 import (
+	"guestbook/common/coord"
 	"guestbook/entity"
 )
 
 type Canvas struct {
 	id   entity.ID
 	size size
-	data registerMap
+	data colors
 }
-
-/*
-TODO : (0, 0) 부터 시작할지 (1, 1) 부터 시작할지?
-(0, 0)은 기본값이므로 문제가 생길 수도 있음.
-일단은 (0, 0)으로 한다. (1, 1)의 경우 값을 클라이언트로 내려줄 때 까다로욱 수도 있음
-*/
-type registerMap map[uint32]LWWRegister
 
 type size struct {
-	width, height uint16
+	height coord.Y
+	width  coord.X
 }
 
-func (canvas *Canvas) Merge(y, x uint16, state *State) {
+func (canvas *Canvas) Merge(y coord.Y, x coord.X, state *State) {
 	key := canvas.getKey(y, x)
 	register, exist := canvas.data[key]
 
@@ -32,12 +27,20 @@ func (canvas *Canvas) Merge(y, x uint16, state *State) {
 	register.Merge(state)
 }
 
-func (canvas *Canvas) getKey(y, x uint16) uint32 {
+func (canvas *Canvas) getKey(y coord.Y, x coord.X) colorKey {
 	width := canvas.size.width
 	height := canvas.size.height
 	// TODO : 예외 발생으로 변경
 	if y >= height || x >= width {
 		return 0
 	}
-	return uint32(y*width + x)
+
+	position := calculatePosition(width, y, x)
+	return colorKey(position)
+}
+
+func calculatePosition(width coord.X, y coord.Y, x coord.X) uint32 {
+	a := uint32(width) * uint32(y)
+	b := uint32(x)
+	return a + b
 }

--- a/register/colors.go
+++ b/register/colors.go
@@ -1,0 +1,10 @@
+package register
+
+/*
+TODO : (0, 0) 부터 시작할지 (1, 1) 부터 시작할지?
+(0, 0)은 기본값이므로 문제가 생길 수도 있음.
+일단은 (0, 0)으로 한다. (1, 1)의 경우 값을 클라이언트로 내려줄 때 까다로욱 수도 있음
+*/
+type colors map[colorKey]LWWRegister
+
+type colorKey uint32

--- a/register/state.go
+++ b/register/state.go
@@ -1,14 +1,14 @@
 package register
 
 import (
-	"guestbook/entity/entity"
+	"guestbook/entity/user"
 	"guestbook/rgb"
 )
 
 type State struct {
 	color     rgb.RGB
-	timestamp uint32
-	owner     entity.User
+	timestamp Timestamp
+	owner     user.User
 }
 
 func (state *State) SetColor(rgb rgb.RGB) {

--- a/register/timestamp.go
+++ b/register/timestamp.go
@@ -1,0 +1,3 @@
+package register
+
+type Timestamp uint32

--- a/rgb/rgb.go
+++ b/rgb/rgb.go
@@ -1,13 +1,15 @@
 package rgb
 
 type RGB struct {
-	Red, Green, Blue uint
+	Red, Green, Blue value
 }
 
-func (rgb *RGB) Get() uint {
-	return rgb.Red
-}
+type value uint8
+type Color uint32
 
-type Getter interface {
-	Get() uint
+func (rgb *RGB) GetHexColor() Color {
+	red := uint32(rgb.Red) << 16
+	green := uint32(rgb.Green) << 8
+	blue := uint32(rgb.Blue)
+	return Color(red | green | blue)
 }


### PR DESCRIPTION
## 📒 Issue
#21 

## 🎯 어떤 작업을 했는지
변경 용이, 가독성, 실수 방지를 위한 그림과 레지스터 관련 type들을 래핑한다.
그리고 RGB를 래핑하는 김에 관련 이슈 수행 Issue #19 

1. timestamp uint32값을 Timestamp type으로 래핑함
2. 캔버스의 좌표값 uint16를 y 좌표와 x 좌표로 나누어 coord 타입으로 래핑 -> 계산시 실수 방지를 위해 나눠서 래핑한다
3. 캔버스의 색상 Register 맵과 Key uint32를 type으로 래핑
4. RGB를 나타내는 색상 값들과 이들을 합친 값을 type으로 래핑-> Issue : https://github.com/binary-ho/guest-book/issues/19
5. RGB 관련 값들 압축 계산 기능 구현 -> #10 

## 2. 좌표 계산법
각각의 좌표 Y와 X는 uint16값을 가졌다. 지금 구상으로는 가로 세로 최대 uint16이면 크기가 충분해 보이기 때문이다. 이를 Map의 key로 간편하게 활용하기 위해 uint32로 사용하도록 변경했다.
공식은 (캔버스의 넓이) * Y + X 이다.

## 3. RGB 값을 하나의 변수로 나타내기
RGB값은 각각 uint 8로 나타낼 수 있다. Shitf 연산을 활용해 이를 하나의 uint32값으로 만들었다
그런데 조금 더 고민해야 할 것 같다.

사실 목적이 결국 JSON 통신과 데이터 캐싱시 최대한 가볍게 저장할 수 있게 하는 것이 목적인데, uint8 3개를 합쳐 unit32로 나타내면 더 큰 용량을 차지하는 것이 아닌가? 
결국 아래 2가지 관리법이 각각 JSON으로 통신할 때와 변수로 관리될 때 얼마큼의 용량을 차지하는지를 비교해야 한다.

1. int8 변수 3개로 관리
2. int32 변수 1개로 관리