### PR TITLE
[🌎 Feature] API Handler 및 Controller 구현

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -1,8 +1,29 @@
 package main
 
-import "log/slog"
+import (
+	"database/sql"
+	"log/slog"
+)
 
 type application struct {
 	logger *slog.Logger
 	config Config
+	db     sql.DB
+
+	controllers  *controllers
+	services     *Services
+	repositories *Repositories
+}
+
+func InitApplicationContext(logger *slog.Logger, config Config, db *sql.DB) *application {
+	app := &application{
+		logger: logger,
+		config: config,
+		db:     *db,
+	}
+
+	app.initRepositories()
+	app.initServices()
+	app.initControllers()
+	return app
 }

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -8,7 +8,7 @@ import (
 type application struct {
 	logger *slog.Logger
 	config Config
-	db     sql.DB
+	db     *sql.DB
 
 	controllers  *controllers
 	services     *Services
@@ -19,7 +19,7 @@ func InitApplicationContext(logger *slog.Logger, config Config, db *sql.DB) *app
 	app := &application{
 		logger: logger,
 		config: config,
-		db:     *db,
+		db:     db,
 	}
 
 	app.initRepositories()

--- a/cmd/controllers.go
+++ b/cmd/controllers.go
@@ -1,0 +1,14 @@
+package main
+
+import "guestbook/entity/user"
+
+type controllers struct {
+	userController *user.Controller
+}
+
+func (app *application) initControllers() {
+	services := app.services
+	app.controllers = &controllers{
+		userController: user.InitController(services.userService),
+	}
+}

--- a/cmd/repositories.go
+++ b/cmd/repositories.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"guestbook/entity/user"
+)
+
+type Repositories struct {
+	userRepository *user.Repository
+}
+
+func (app *application) initRepositories() {
+	app.repositories = &Repositories{
+		userRepository: user.NewRepository(&app.db),
+	}
+}

--- a/cmd/repositories.go
+++ b/cmd/repositories.go
@@ -10,6 +10,6 @@ type Repositories struct {
 
 func (app *application) initRepositories() {
 	app.repositories = &Repositories{
-		userRepository: user.NewRepository(&app.db),
+		userRepository: user.NewRepository(app.db),
 	}
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"guestbook/entity/user"
+	"net/http"
+)
+
+func (app *application) routes() {
+	controllers := app.controllers
+	serveMux := http.NewServeMux()
+
+	serveUserApis(controllers.userController, serveMux)
+}
+
+func serveUserApis(controller *user.Controller, serveMux *http.ServeMux) {
+	serveMux.HandleFunc(controller.SignUp())
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -1,0 +1,14 @@
+package main
+
+import "guestbook/entity/user"
+
+type Services struct {
+	userService *user.Service
+}
+
+func (app *application) initServices() {
+	repositories := app.repositories
+	app.services = &Services{
+		userService: user.InitService(repositories.userRepository),
+	}
+}

--- a/common/response/entity.go
+++ b/common/response/entity.go
@@ -1,0 +1,35 @@
+package response
+
+import (
+	"encoding/json"
+	"errors"
+	"guestbook/common/util"
+	"net/http"
+	"strconv"
+)
+
+const (
+	ContentTypeKey  = "Content-Type"
+	JsonContentType = "application/json"
+)
+
+func Create(writer *http.ResponseWriter, responseBody any, status int) error {
+	err := json.NewEncoder(*writer).Encode(responseBody)
+	if err != nil {
+		Error(*writer, http.StatusNotFound)
+		return err
+	}
+
+	(*writer).Header().Set(ContentTypeKey, JsonContentType)
+	(*writer).WriteHeader(status)
+	err = validateStatusNumber(status)
+	return err
+}
+
+func validateStatusNumber(status int) error {
+	text := http.StatusText(status)
+	if util.IsBlank(text) {
+		return errors.New("Wrong Status Code : " + strconv.Itoa(status))
+	}
+	return nil
+}

--- a/common/response/error.go
+++ b/common/response/error.go
@@ -1,0 +1,9 @@
+package response
+
+import (
+	"net/http"
+)
+
+func Error(writer http.ResponseWriter, status int) {
+	http.Error(writer, http.StatusText(status), status)
+}

--- a/default.golangci.yml
+++ b/default.golangci.yml
@@ -144,7 +144,7 @@ linters-settings:
       - "-SA9004" # <https://staticcheck.io/docs/checks#SA9004>
   gocritic:
     disabled-checks:
-      - exitAfterDefer # panic is required when examines config
+      - exitAfterDefer # panic is required when examines property
 linters:
   enable:
     - errcheck # checks unchecked errors

--- a/entity/user/controller.go
+++ b/entity/user/controller.go
@@ -1,0 +1,45 @@
+package user
+
+import (
+	"encoding/json"
+	"guestbook/common/response"
+	"guestbook/entity"
+	user "guestbook/entity/user/dto"
+	"net/http"
+)
+
+type Controller struct {
+	service *Service
+}
+
+func InitController(service *Service) *Controller {
+	return &Controller{service: service}
+}
+
+func (controller *Controller) SignUp() (string, func(http.ResponseWriter, *http.Request)) {
+	SignUpEndpoint := "POST /user"
+	return SignUpEndpoint, controller.signUp
+}
+
+func (controller *Controller) signUp(writer http.ResponseWriter, request *http.Request) {
+	var signUpRequest user.SignUpRequest
+	err := json.NewDecoder(request.Body).Decode(&signUpRequest)
+	if err != nil {
+		response.Error(writer, http.StatusNotFound)
+		return
+	}
+	service := controller.service
+	githubId := entity.ID(signUpRequest.GithubId)
+
+	id, err := service.SignUp(signUpRequest.Handle, githubId, signUpRequest.ProfileUrl)
+	if err != nil {
+		response.Error(writer, http.StatusNotFound)
+		return
+	}
+
+	err = response.Create(&writer, id, http.StatusCreated)
+	if err != nil {
+		response.Error(writer, http.StatusNotFound)
+		return
+	}
+}

--- a/entity/user/dto/signuprequest.go
+++ b/entity/user/dto/signuprequest.go
@@ -1,0 +1,7 @@
+package user
+
+type SignUpRequest struct {
+	Handle     string
+	GithubId   uint
+	ProfileUrl string
+}

--- a/entity/user/plan.go
+++ b/entity/user/plan.go
@@ -12,7 +12,7 @@ type plan struct {
 }
 
 const (
-	FREE  = "FREE"
+	Free  = "Free"
 	JJANG = "JJANG"
 )
 
@@ -24,13 +24,13 @@ func init() {
 	}
 
 	plans = map[string]plan{
-		FREE:  {name: FREE, level: 1},
+		Free:  {name: Free, level: 1},
 		JJANG: {name: JJANG, level: 2},
 	}
 }
 
 func FreePlan() plan {
-	return plans[FREE]
+	return plans[Free]
 }
 
 func JjangPlan() plan {

--- a/entity/user/service.go
+++ b/entity/user/service.go
@@ -1,0 +1,50 @@
+package user
+
+import (
+	"errors"
+	"guestbook/common"
+	"guestbook/entity"
+)
+
+type Service struct {
+	userRepository *Repository
+}
+
+func InitService(userRepository *Repository) *Service {
+	return &Service{userRepository: userRepository}
+}
+
+func (service *Service) SignUp(
+	handle string, githubId entity.ID, profileUrl string) (entity.ID, error) {
+	userRepository := service.userRepository
+	if userRepository.ExistsByGithubId(githubId) {
+		return entity.DefaultId(), errors.New("[ERROR] user Already Exist")
+	}
+
+	user, err := createFreeUser(handle, githubId, profileUrl)
+	if err != nil {
+		return entity.DefaultId(), err
+	}
+
+	savedUser, err := userRepository.Save(*user)
+	if err != nil {
+		return entity.DefaultId(), err
+	}
+
+	return savedUser.id, err
+}
+
+func createFreeUser(handle string, githubId entity.ID, profileUrl string) (*Entity, error) {
+	url, err := common.CreateUrl(profileUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Entity{
+		handle:     handle,
+		nickname:   handle,
+		githubId:   githubId,
+		profileUrl: url,
+		plan:       FreePlan(),
+	}, nil
+}


### PR DESCRIPTION
## 📒 Issue
#28 

## 🎯 어떤 작업을 했는지
기본 회원가입 API와 Handler 구현

1. application context가 compoent 리스트를 갖도록 구현해봤다. <Br> 전역적으로 컴포넌트들을 관리하는 것이 좋은 방법인지는 모르겠다. 이렇게 구현한 이유는, 첫 번째로 어차피 DB Pool은 전역적이기 때문에, Repository들을 가지고 있어야 한다고 생각했고, <br> 또한 한 군데에서 편하게 API들을 serve 하기 위해 application context가 모든 API의 컴포넌트들을 갖는 방법으로 구현한 것이다. 
2. Controller가 Endpoint와 Handler를 직접 반환하게 구현해봤다. <br> 응집도를 높이기 위한 노력이다. 원래 API를 serve 할 때, 인자를 엔드포인트와 핸들러를 넣어줘야 했다. 이 때 serve를 호출하는 곳에서 Endpoint를 직접 넣어준다면 마치 serve를 호출하는 곳에서 Endpoint를 결정하는 것만 같아 싫었다. <br> 그래서 어떤 요청을 처리하는 메서드가 직접 엔드포인트를 들고 있길 원해 이렇게 구현해 보았다.